### PR TITLE
fix wrong size error

### DIFF
--- a/org.freedownloadmanager.Manager.metainfo.xml
+++ b/org.freedownloadmanager.Manager.metainfo.xml
@@ -20,6 +20,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="6.19.0.5156" date="2023-05-11"/>
     <release version="6.17.0.4792" date="2022-08-18"/>
     <release version="6.16.2.4586" date="2022-05-16"/>
   </releases>

--- a/org.freedownloadmanager.Manager.yaml
+++ b/org.freedownloadmanager.Manager.yaml
@@ -83,7 +83,7 @@ modules:
         path: icons/org.freedownloadmanager.Manager-256.png
 
       - type: extra-data
-        url: https://dn3.freedownloadmanager.org/6/latest/freedownloadmanager.deb
+        url: https://files2.freedownloadmanager.org/6/latest/freedownloadmanager.deb
         sha256: d59aa9be2a08fc500052bd0cae8515da7cd408f1d0ce00477d2349d29baa40ec
         filename: freedownloadmanager.deb
         size: 28046160

--- a/org.freedownloadmanager.Manager.yaml
+++ b/org.freedownloadmanager.Manager.yaml
@@ -84,7 +84,7 @@ modules:
 
       - type: extra-data
         url: https://files2.freedownloadmanager.org/6/latest/freedownloadmanager.deb
-        sha256: d59aa9be2a08fc500052bd0cae8515da7cd408f1d0ce00477d2349d29baa40ec
+        sha256: dca98d8641043b35b9aa22ba7b864f23dc1b4dd0361055941f96752bc91d5d6c
         filename: freedownloadmanager.deb
-        size: 28046160
+        size: 42601756
         only-arches: [x86_64]


### PR DESCRIPTION
This fix for wrong size error. Due to old version not available.
```
Error: Wrong size for extra data https://dn3.freedownloadmanager.org/6/latest/freedownloadmanager.deb
error: Failed to install org.freedownloadmanager.Manager: Wrong size for extra data https://dn3.freedownloadmanager.org/6/latest/freedownloadmanager.deb
```