### PR TITLE
update deprecated boost url

### DIFF
--- a/org.freedownloadmanager.Manager.yaml
+++ b/org.freedownloadmanager.Manager.yaml
@@ -29,7 +29,7 @@ modules:
         linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
+        url: https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.bz2
         sha256: 475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39
 
 


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
